### PR TITLE
FPS counter was not updating and calculating correctly

### DIFF
--- a/lutro.c
+++ b/lutro.c
@@ -606,8 +606,9 @@ void lutro_run(double delta)
    settings.delta = delta;
    settings.deltaCounter += delta;
    settings.frameCounter += 1;
+   settings.fps = 1 / delta;
+
    if (settings.deltaCounter >= 1.0) {
-      settings.fps = settings.frameCounter;
       settings.frameCounter = 0;
       settings.deltaCounter = 0;
    }


### PR DESCRIPTION
- Fix getFPS() which was not calculating and updating correctly

You can run `examples/benchmark` to test