### PR TITLE
font: support UTF8 rendering

### DIFF
--- a/painter.h
+++ b/painter.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <boolean.h>
 
+#define MAX_FONT_CHAR 256
+
 enum {
    FONT_FREETYPE = 1 << 1,
    FONT_BOLD     = 1 << 2,
@@ -25,8 +27,8 @@ typedef struct
    unsigned flags;
    unsigned pxsize;
 
-   int  separators[256];
-   char characters[256];
+   int  separators[MAX_FONT_CHAR];
+   uint32_t characters[MAX_FONT_CHAR];
 } font_t;
 
 typedef struct


### PR DESCRIPTION
The code relies on utf8_conv_utf32 from libretro-common

On linux LUA string are UTF8, others OSes weren't tested
If the string isn't utf8, utf8_conv_utf32 call must be replaced

Extra: if the glyph isn't found on the atlas, the glyph rendering is
now skipped (rather than random behavior/crash)

I didn't update the 256 glyph limits, I believe it would be better
to have proper malloc/free here

Edit: I did a quick hack to test utf on arsene but extra tests would be a good idea